### PR TITLE
Updated Directions Page

### DIFF
--- a/stopBApp/templates/directions.html
+++ b/stopBApp/templates/directions.html
@@ -224,11 +224,12 @@
           loadingOverlay.style.display = 'flex';
           loadingOverlay.innerText = "Getting Directions.";
         }
+        // Always request route alternatives to retain all routes.
         directionsService.route({
           origin: origin,
           destination: destination,
           travelMode: google.maps.TravelMode.WALKING,
-          provideRouteAlternatives: liveNavigation ? false : true
+          provideRouteAlternatives: true
         }, (result, status) => {
           if (status === google.maps.DirectionsStatus.OK) {
             renderRoutes(result);
@@ -251,7 +252,7 @@
           // Hide the routes list and modal.
           document.getElementById('routes-list').style.display = 'none';
           modal.style.display = 'none';
-          // Re-request directions using the confirmed route.
+          // Re-request directions using the confirmed route while keeping alternatives.
           const origin = lastUserPosition || defaultOrigin;
           requestDirections(origin);
         };

--- a/stopBApp/templates/directions.html
+++ b/stopBApp/templates/directions.html
@@ -3,45 +3,324 @@
   <head>
     <title>Route Directions</title>
     <style>
-      #map { height: 500px; width: 100%; }
+      body {
+        font-family: Arial, sans-serif;
+        background: #f4f4f4;
+        margin: 0;
+        padding: 0;
+      }
+      .container {
+        max-width: 900px;
+        margin: 20px auto;
+        padding: 0 20px;
+      }
+      .map-wrapper {
+        position: relative;
+        border: 1px solid #ddd;
+        background: #fff;
+      }
+      #map {
+        height: 500px;
+        width: 100%;
+      }
+      /* Loading overlay */
+      #loading {
+        position: absolute;
+        top: 0;
+        left: 0;
+        width: 100%;
+        height: 500px;
+        background: rgba(255, 255, 255, 0.8);
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        font-size: 24px;
+        color: #333;
+        z-index: 1000;
+      }
+      /* Routes list styling */
+      #routes-list {
+        margin-top: 10px;
+        padding: 10px;
+        background: #fff;
+        border: 1px solid #ddd;
+      }
+      .route-item {
+        padding: 8px;
+        border-bottom: 1px solid #eee;
+        cursor: pointer;
+      }
+      .route-item:hover {
+        background: #f0f0f0;
+      }
+      /* Live navigation info panel */
+      #live-info {
+        margin-top: 10px;
+        padding: 10px;
+        background: #fff;
+        border: 1px solid #ddd;
+        font-size: 16px;
+      }
+      /* Modal styles */
+      .modal {
+        display: none;
+        position: fixed;
+        z-index: 2000;
+        left: 0;
+        top: 0;
+        width: 100%;
+        height: 100%;
+        overflow: auto;
+        background: rgba(0,0,0,0.5);
+      }
+      .modal-content {
+        background: #fff;
+        margin: 15% auto;
+        padding: 20px;
+        border: 1px solid #888;
+        width: 80%;
+        max-width: 400px;
+        text-align: center;
+      }
+      .close {
+        color: #aaa;
+        float: right;
+        font-size: 28px;
+        font-weight: bold;
+        cursor: pointer;
+      }
+      .close:hover,
+      .close:focus {
+        color: black;
+      }
+      button {
+        padding: 10px 20px;
+        margin-top: 10px;
+        border: none;
+        background: #4285F4;
+        color: #fff;
+        cursor: pointer;
+        font-size: 16px;
+      }
+      button:hover {
+        background: #3367d6;
+      }
     </style>
+    <!-- Load the Google Maps JavaScript API -->
     <script src="https://maps.googleapis.com/maps/api/js?key={{ google_maps_api_key }}&callback=initMap" async defer></script>
     <script>
+      // Global variables
+      let map, userLocationCircle, loadingOverlay;
+      let renderers = [];
+      let infoWindows = [];
+      let lastUserPosition = null;
+      let directionsService;
+      let destination, defaultOrigin;
+      let currentDirectionsResponse = null;
+      let liveNavigation = false;
+      let selectedRouteIndex = 0;
+      let loadingInterval = null;  // For cycling the loading text
+
+      // Clear existing route renderers and info windows
+      function clearRenderers() {
+        renderers.forEach(renderer => renderer.setMap(null));
+        renderers = [];
+      }
+      function clearInfoWindows() {
+        infoWindows.forEach(iw => iw.close());
+        infoWindows = [];
+      }
+      
+      // Update turn-by-turn directions under the map.
+      function updateTurnByTurnDirections() {
+        if (!currentDirectionsResponse) return;
+        const selectedRoute = currentDirectionsResponse.routes[selectedRouteIndex];
+        const leg = selectedRoute.legs[0];
+        if (leg) {
+          let directionsHtml = "<h3>Turn-by-Turn Directions:</h3>";
+          leg.steps.forEach((step, index) => {
+            // step.instructions usually contains HTML (like "Turn left onto Main St")
+            directionsHtml += `<p>${step.instructions} - <strong>${step.distance.text}</strong></p>`;
+          });
+          document.getElementById('live-info').innerHTML = directionsHtml;
+        }
+      }
+      
+      // Render the routes; if in live navigation mode, only render the selected route.
+      function renderRoutes(response) {
+        clearRenderers();
+        clearInfoWindows();
+        // Stop loading animation.
+        if (loadingOverlay) loadingOverlay.style.display = 'none';
+        currentDirectionsResponse = response;
+        const routes = response.routes;
+        
+        if (!liveNavigation) {
+          // Build the routes list.
+          const routesListContainer = document.getElementById('routes-list');
+          routesListContainer.innerHTML = "";
+          routes.forEach((route, index) => {
+            const renderer = new google.maps.DirectionsRenderer({
+              map: map,
+              directions: response,
+              routeIndex: index,
+              suppressMarkers: false,
+              polylineOptions: {
+                strokeColor: index === 0 ? '#0000FF' : '#FF0000',
+                strokeOpacity: index === 0 ? 1.0 : 0.8,
+                strokeWeight: index === 0 ? 6 : 4
+              }
+            });
+            renderers.push(renderer);
+            
+            const leg = route.legs[0];
+            const distanceText = leg.distance.text;
+            const durationText = leg.duration.text;
+            // Optional info window on the route.
+            if (leg) {
+              const midStep = leg.steps[Math.floor(leg.steps.length / 2)];
+              const midpoint = midStep.start_location;
+              const infoWindow = new google.maps.InfoWindow({
+                content: `Route ${index+1}: ${distanceText}, ${durationText}`,
+                position: midpoint
+              });
+              infoWindow.open(map);
+              infoWindows.push(infoWindow);
+            }
+            
+            // Build clickable list item for route selection.
+            const routeItem = document.createElement('div');
+            routeItem.className = "route-item";
+            routeItem.innerHTML = `<strong>Route ${index+1}</strong>: ${distanceText}, ${durationText}`;
+            routeItem.onclick = function() {
+              showRouteModal(index, distanceText, durationText);
+            };
+            routesListContainer.appendChild(routeItem);
+          });
+        } else {
+          // Live navigation: render only the selected route.
+          const renderer = new google.maps.DirectionsRenderer({
+            map: map,
+            directions: response,
+            routeIndex: selectedRouteIndex,
+            suppressMarkers: false,
+            polylineOptions: {
+              strokeColor: '#0000FF',
+              strokeOpacity: 1.0,
+              strokeWeight: 6
+            }
+          });
+          renderers.push(renderer);
+          updateTurnByTurnDirections();
+        }
+      }
+      
+      // Request directions from a given origin.
+      function requestDirections(origin) {
+        clearRenderers();
+        clearInfoWindows();
+        // Start the loading animation.
+        if (loadingOverlay) {
+          loadingOverlay.style.display = 'flex';
+          loadingOverlay.innerText = "Getting Directions.";
+        }
+        directionsService.route({
+          origin: origin,
+          destination: destination,
+          travelMode: google.maps.TravelMode.WALKING,
+          provideRouteAlternatives: liveNavigation ? false : true
+        }, (result, status) => {
+          if (status === google.maps.DirectionsStatus.OK) {
+            renderRoutes(result);
+          } else {
+            alert('Directions request failed due to ' + status);
+            if (loadingOverlay) loadingOverlay.style.display = 'none';
+          }
+        });
+      }
+      
+      // Show a modal with route details. When confirmed, switch into live navigation mode.
+      function showRouteModal(routeIndex, distanceText, durationText) {
+        const modal = document.getElementById('route-modal');
+        const modalText = document.getElementById('modal-text');
+        modalText.innerHTML = `Route ${routeIndex+1}: ${distanceText}, ${durationText}.<br>Start live navigation within our app?`;
+        modal.style.display = 'block';
+        document.getElementById('confirm-route').onclick = function() {
+          selectedRouteIndex = routeIndex;
+          liveNavigation = true;
+          // Hide the routes list and modal.
+          document.getElementById('routes-list').style.display = 'none';
+          modal.style.display = 'none';
+          // Re-request directions using the confirmed route.
+          const origin = lastUserPosition || defaultOrigin;
+          requestDirections(origin);
+        };
+      }
+      
+      function closeModal() {
+        document.getElementById('route-modal').style.display = 'none';
+      }
+      
+      // Helper: compute distance (meters) between two coordinates.
+      function computeDistance(coord1, coord2) {
+        const R = 6371000;
+        const toRad = x => x * Math.PI / 180;
+        const dLat = toRad(coord2.lat - coord1.lat);
+        const dLon = toRad(coord2.lng - coord1.lng);
+        const a = Math.sin(dLat/2) ** 2 +
+                  Math.cos(toRad(coord1.lat)) * Math.cos(toRad(coord2.lat)) *
+                  Math.sin(dLon/2) ** 2;
+        const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1-a));
+        return R * c;
+      }
+      
+      // Initialize the map and set up geolocation.
       function initMap() {
-        const destination = {
+        destination = {
           lat: parseFloat('{{ destination_coords.0 }}'),
           lng: parseFloat('{{ destination_coords.1 }}')
         };
-        const defaultOrigin = {
+        defaultOrigin = {
           lat: parseFloat('{{ origin_coords.0 }}'),
           lng: parseFloat('{{ origin_coords.1 }}')
         };
-
-        const map = new google.maps.Map(document.getElementById('map'), {
+        
+        map = new google.maps.Map(document.getElementById('map'), {
           center: destination,
-          zoom: 12
+          zoom: 13
         });
-        const directionsService = new google.maps.DirectionsService();
-        const directionsRenderer = new google.maps.DirectionsRenderer({ map });
-
-        const requestDirections = (origin) => {
-          directionsService.route({
-            origin: origin,
-            destination: destination,
-            travelMode: google.maps.TravelMode.WALKING
-          }, (result, status) => {
-            if (status === google.maps.DirectionsStatus.OK) {
-              directionsRenderer.setDirections(result);
-            } else {
-              alert('Directions request failed due to ' + status);
-            }
-          });
-        };
-
+        
+        loadingOverlay = document.getElementById('loading');
+        
+        // Start loading animation: cycle dots.
+        loadingInterval = setInterval(function() {
+          if (loadingOverlay && loadingOverlay.style.display !== 'none') {
+            let text = loadingOverlay.innerText;
+            let baseText = "Getting Directions";
+            let dotCount = (text.match(/\./g) || []).length;
+            dotCount = (dotCount + 1) % 4;
+            loadingOverlay.innerText = baseText + ".".repeat(dotCount);
+          }
+        }, 500);
+        
+        userLocationCircle = new google.maps.Circle({
+          map: map,
+          radius: 20,
+          fillColor: '#0000FF',
+          fillOpacity: 0.5,
+          strokeColor: '#0000FF',
+          strokeOpacity: 0.8,
+          strokeWeight: 2
+        });
+        
+        directionsService = new google.maps.DirectionsService();
+        
+        // Get the initial user location.
         if (navigator.geolocation) {
           navigator.geolocation.getCurrentPosition(
             pos => {
               const userCoords = { lat: pos.coords.latitude, lng: pos.coords.longitude };
+              lastUserPosition = userCoords;
               map.setCenter(userCoords);
               requestDirections(userCoords);
             },
@@ -50,15 +329,52 @@
               requestDirections(defaultOrigin);
             }
           );
+          // Watch position for live updates.
+          navigator.geolocation.watchPosition(
+            pos => {
+              const newUserCoords = { lat: pos.coords.latitude, lng: pos.coords.longitude };
+              userLocationCircle.setCenter(newUserCoords);
+              if (!lastUserPosition || computeDistance(lastUserPosition, newUserCoords) > 10) {
+                lastUserPosition = newUserCoords;
+                requestDirections(newUserCoords);
+              }
+            },
+            err => console.error("Live geolocation error:", err.message),
+            { enableHighAccuracy: true }
+          );
         } else {
           console.error("Geolocation not supported.");
           requestDirections(defaultOrigin);
         }
       }
+      
+      // Close modal if clicked outside.
+      window.onclick = function(event) {
+        const modal = document.getElementById('route-modal');
+        if (event.target === modal) {
+          modal.style.display = 'none';
+        }
+      }
     </script>
   </head>
   <body>
-    <h1>Directions from Your Location to {{ destination }}</h1>
-    <div id="map"></div>
+    <div class="container">
+      <h1>Directions to {{ destination }}</h1>
+      <div class="map-wrapper">
+        <div id="map"></div>
+        <div id="loading">Getting Directions.</div>
+      </div>
+      <div id="routes-list"></div>
+      <div id="live-info"></div>
+    </div>
+    
+    <!-- Modal for route selection confirmation -->
+    <div id="route-modal" class="modal">
+      <div class="modal-content">
+        <span class="close" id="modal-close" onclick="closeModal()">&times;</span>
+        <p id="modal-text"></p>
+        <button id="confirm-route">Confirm Navigation</button>
+      </div>
+    </div>
   </body>
 </html>

--- a/stopBApp/templates/directions.html
+++ b/stopBApp/templates/directions.html
@@ -121,7 +121,7 @@
       let selectedRouteIndex = 0;
       let loadingInterval = null;  // For cycling the loading text
 
-      // Clear existing route renderers and info windows
+      // Clear existing route renderers and info windows.
       function clearRenderers() {
         renderers.forEach(renderer => renderer.setMap(null));
         renderers = [];
@@ -130,7 +130,57 @@
         infoWindows.forEach(iw => iw.close());
         infoWindows = [];
       }
-      
+
+      // Helper function to strip HTML tags from a string.
+      function stripHtml(html) {
+        const tmp = document.createElement("DIV");
+        tmp.innerHTML = html;
+        return tmp.textContent || tmp.innerText || "";
+      }
+
+      // Helper: Custom format for each step.
+      function formatStepText(step, isFinal) {
+        let instruction = stripHtml(step.instructions).trim();
+        let distance = step.distance.text;
+
+        // Final step: "Destination will be on the left/right in ___ feet"
+        if (isFinal) {
+          let lowerInst = instruction.toLowerCase();
+          let side = lowerInst.includes("right") ? "right" : "left";
+          return `Destination will be on the ${side} in ${distance}`;
+        }
+        // Step starts with "Head ..."
+        else if (instruction.startsWith("Head")) {
+          // e.g. "Head east"
+          let parts = instruction.split(" ");
+          let direction = parts[1] || "";
+          return `Head ${direction} for ${distance}`;
+        }
+        // Step starts with "Turn ..."
+        else if (instruction.startsWith("Turn")) {
+          // Attempt to parse "Turn left/right ..." and possibly the street name.
+          // If no street name is found, fallback to "Turn left in ___"
+          let regex = /^Turn\s+(left|right)(?:\s+(?:onto\s+)?(.*))?/i;
+          let match = instruction.match(regex);
+          if (match) {
+            let turnDir = match[1];
+            let street = (match[2] || "").trim();
+            if (street) {
+              return `Turn ${turnDir} towards ${street} in ${distance}`;
+            } else {
+              return `Turn ${turnDir} in ${distance}`;
+            }
+          } else {
+            // If we can't parse it at all, fallback:
+            return `${instruction} - ${distance}`;
+          }
+        }
+        // Fallback: show original instruction with distance
+        else {
+          return `${instruction} - ${distance}`;
+        }
+      }
+
       // Update turn-by-turn directions under the map.
       function updateTurnByTurnDirections() {
         if (!currentDirectionsResponse) return;
@@ -139,24 +189,23 @@
         if (leg) {
           let directionsHtml = "<h3>Turn-by-Turn Directions:</h3>";
           leg.steps.forEach((step, index) => {
-            // step.instructions usually contains HTML (like "Turn left onto Main St")
-            directionsHtml += `<p>${step.instructions} - <strong>${step.distance.text}</strong></p>`;
+            const isFinal = (index === leg.steps.length - 1);
+            const formattedStep = formatStepText(step, isFinal);
+            directionsHtml += `<p>${formattedStep}</p>`;
           });
           document.getElementById('live-info').innerHTML = directionsHtml;
         }
       }
-      
-      // Render the routes; if in live navigation mode, only render the selected route.
+
+      // Render the routes; if in live navigation mode, render only the selected route.
       function renderRoutes(response) {
         clearRenderers();
         clearInfoWindows();
-        // Stop loading animation.
         if (loadingOverlay) loadingOverlay.style.display = 'none';
         currentDirectionsResponse = response;
         const routes = response.routes;
         
         if (!liveNavigation) {
-          // Build the routes list.
           const routesListContainer = document.getElementById('routes-list');
           routesListContainer.innerHTML = "";
           routes.forEach((route, index) => {
@@ -176,7 +225,6 @@
             const leg = route.legs[0];
             const distanceText = leg.distance.text;
             const durationText = leg.duration.text;
-            // Optional info window on the route.
             if (leg) {
               const midStep = leg.steps[Math.floor(leg.steps.length / 2)];
               const midpoint = midStep.start_location;
@@ -214,17 +262,16 @@
           updateTurnByTurnDirections();
         }
       }
-      
+
       // Request directions from a given origin.
       function requestDirections(origin) {
         clearRenderers();
         clearInfoWindows();
-        // Start the loading animation.
         if (loadingOverlay) {
           loadingOverlay.style.display = 'flex';
           loadingOverlay.innerText = "Getting Directions.";
         }
-        // Always request route alternatives to retain all routes.
+        // Always request route alternatives.
         directionsService.route({
           origin: origin,
           destination: destination,
@@ -239,7 +286,7 @@
           }
         });
       }
-      
+
       // Show a modal with route details. When confirmed, switch into live navigation mode.
       function showRouteModal(routeIndex, distanceText, durationText) {
         const modal = document.getElementById('route-modal');
@@ -249,19 +296,17 @@
         document.getElementById('confirm-route').onclick = function() {
           selectedRouteIndex = routeIndex;
           liveNavigation = true;
-          // Hide the routes list and modal.
           document.getElementById('routes-list').style.display = 'none';
           modal.style.display = 'none';
-          // Re-request directions using the confirmed route while keeping alternatives.
           const origin = lastUserPosition || defaultOrigin;
           requestDirections(origin);
         };
       }
-      
+
       function closeModal() {
         document.getElementById('route-modal').style.display = 'none';
       }
-      
+
       // Helper: compute distance (meters) between two coordinates.
       function computeDistance(coord1, coord2) {
         const R = 6371000;
@@ -274,7 +319,7 @@
         const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1-a));
         return R * c;
       }
-      
+
       // Initialize the map and set up geolocation.
       function initMap() {
         destination = {
@@ -292,8 +337,8 @@
         });
         
         loadingOverlay = document.getElementById('loading');
-        
-        // Start loading animation: cycle dots.
+
+        // Start loading animation: cycle the dots.
         loadingInterval = setInterval(function() {
           if (loadingOverlay && loadingOverlay.style.display !== 'none') {
             let text = loadingOverlay.innerText;
@@ -316,7 +361,6 @@
         
         directionsService = new google.maps.DirectionsService();
         
-        // Get the initial user location.
         if (navigator.geolocation) {
           navigator.geolocation.getCurrentPosition(
             pos => {
@@ -330,7 +374,6 @@
               requestDirections(defaultOrigin);
             }
           );
-          // Watch position for live updates.
           navigator.geolocation.watchPosition(
             pos => {
               const newUserCoords = { lat: pos.coords.latitude, lng: pos.coords.longitude };
@@ -348,8 +391,7 @@
           requestDirections(defaultOrigin);
         }
       }
-      
-      // Close modal if clicked outside.
+
       window.onclick = function(event) {
         const modal = document.getElementById('route-modal');
         if (event.target === modal) {

--- a/stopBApp/views/directions_views.py
+++ b/stopBApp/views/directions_views.py
@@ -1,60 +1,40 @@
-from django.views import View
-import requests
-from django.shortcuts import render
+from django.views.generic import TemplateView
 from django.http import HttpResponseBadRequest
 from django.conf import settings
+import requests
 
-class Directions(View):
-    def get(self, request):
-        origin_input = request.GET.get('origin', '').strip()
+class Directions(TemplateView):
+    template_name = "directions.html"
+
+    def get(self, request, *args, **kwargs):
+        # Only require a destination parameter.
         destination_input = request.GET.get('destination', '').strip()
+        if not destination_input:
+            return HttpResponseBadRequest("The 'destination' parameter is required.")
 
-        if not origin_input or not destination_input:
-            return HttpResponseBadRequest("Both 'origin' and 'destination' parameters are required.")
-
-        origin_coords = parse_location(origin_input)
         destination_coords = parse_location(destination_input)
+        if not destination_coords:
+            return HttpResponseBadRequest("Invalid destination location provided.")
 
-        if not (origin_coords and destination_coords):
-            return HttpResponseBadRequest("Invalid origin or destination location provided.")
-
-        payload = {
-            "origin": {"location": {"latLng": {"latitude": origin_coords[0], "longitude": origin_coords[1]}}},
-            "destination": {"location": {"latLng": {"latitude": destination_coords[0], "longitude": destination_coords[1]}}},
-            "travelMode": "WALK",
-            "computeAlternativeRoutes": True
-        }
-        routes_url = "https://routes.googleapis.com/directions/v2:computeRoutes"
-        params = {"key": settings.MAPS_API_KEY}
-        headers = {"X-Goog-FieldMask": "routes.distanceMeters,routes.duration,routes.polyline.encodedPolyline"}
-
-        routes_response = requests.post(routes_url, params=params, json=payload, headers=headers)
-        if routes_response.status_code != 200:
-            return HttpResponseBadRequest("Routes API error: " + routes_response.text)
-        
-        routes_data = routes_response.json()
-        if "error" in routes_data or not routes_data.get("routes", []):
-            return HttpResponseBadRequest("Routes API error: " +
-                                          routes_data.get("error", {}).get("message", "No routes found."))
-        encoded_polyline = routes_data["routes"][0].get("polyline", {}).get("encodedPolyline", "")
-
-        context = {
-            "origin": origin_input,
+        context = self.get_context_data(**kwargs)
+        context.update({
             "destination": destination_input,
-            "route_polyline": encoded_polyline,
+            "destination_coords": destination_coords,  # (lat, lng) tuple
             "google_maps_api_key": settings.MAPS_API_KEY,
-            "origin_coords": origin_coords,
-            "destination_coords": destination_coords,
-        }
-        return render(request, "directions.html", context)
+        })
+        return self.render_to_response(context)
+
 
 def parse_location(location_str):
+    # Attempt to parse a "lat,lng" string.
     if ',' in location_str:
         try:
             return tuple(map(float, location_str.split(',')))
         except ValueError:
             pass
+    # Otherwise, try to geocode it.
     return geocode_address(location_str)
+
 
 def geocode_address(address):
     geocode_url = "https://maps.googleapis.com/maps/api/geocode/json"
@@ -64,5 +44,5 @@ def geocode_address(address):
         result = response.json()
         if result.get("status") == "OK" and result.get("results"):
             loc = result["results"][0]["geometry"]["location"]
-            return loc["lat"], loc["lng"]
+            return (loc["lat"], loc["lng"])
     return None


### PR DESCRIPTION
Updated the directions page to show multiple routes, allow the user to pick a route, and begin navigation with turn by turn directions. Now only requires destination coordinates to be passed in the url.

Example Usage:
http://127.0.0.1:8000/directions/%22?destination=43.0758287,-87.8863127

Allow the browser to use your location and it will render two route options. Can select a route below the map to confirm navigation with that route.